### PR TITLE
Improve timezone toggle and advert styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Time Zone Converter</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <h1>Time Zone Converter</h1>
@@ -31,33 +31,32 @@
 
   <!-- Converter form -->
   <form id="converter">
-    <<label id="tmeInputLabel">>
-  <span id="timeLabelText">Your Time:</span>
-      <input type="datetime-local" id="yourTime" />
+    <label id="timeInputLabel">
+      <span id="timeLabelText">Your Time:</span>
+      <input type="datetime-local" id="yourTime">
     </label>
-      <label>
-    Convert direction:
-    <select id="direction">
+
+    <button type="button" id="toggleDirection" class="toggle-btn" aria-label="Swap conversion">⇄</button>
+    <select id="direction" style="display:none">
       <option value="yourToTheir">Your → Their</option>
       <option value="theirToYour">Their → Your</option>
     </select>
-  </label>
 
-    <label>
-      Their Location:
-      <input list="zones" id="theirLocation" placeholder="Start typing city or zone" />
+    <label id="locationLabel">
+      <span id="locationLabelText">Their Location:</span>
+      <input list="zones" id="theirLocation" placeholder="Start typing city or zone">
       <datalist id="zones"></datalist>
     </label>
   </form>
 
   <div class="result">
-    <di<div class="card"><strong id="leftLabel">>Your Time:</strong> <span id="yourTimeDisplay"></span></div>
-<d<div class="card"><strong id="rightLabel">Their Time:</strong> <span id="theirTimeDisplay"></span></div>
+    <div class="card"><strong id="leftLabel">Your Time:</strong> <span id="yourTimeDisplay"></span></div>
+    <div class="card"><strong id="rightLabel">Their Time:</strong> <span id="theirTimeDisplay"></span></div>
   </div>
-    <p class="patreon">If you find this simple tool helpful, feel free to support us on <a href="https://www.patreon.com/evolutionunleashedai" target="_blank">Patreon</a>!</p>
 
-  
-  <<script src="https://cdn.jsdelivr.net/npm/luxon@3/build/global/luxon.min.js"></script>
-<script src="script.js"></script></script>
+  <p class="patreon">If you find this simple tool helpful, feel free to support us on <a href="https://www.patreon.com/evolutionunleashedai" target="_blank">Patreon</a>!</p>
+
+  <script src="https://cdn.jsdelivr.net/npm/luxon@3/build/global/luxon.min.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -5,19 +5,18 @@
   const yourTimeInput = document.getElementById('yourTime');
   const theirLocationInput = document.getElementById('theirLocation');
   const directionSelect = document.getElementById('direction');
+  const toggleButton = document.getElementById('toggleDirection');
   const zonesList = document.getElementById('zones');
   const yourTimeDisplay = document.getElementById('yourTimeDisplay');
   const theirTimeDisplay = document.getElementById('theirTimeDisplay');
   const clockEls = document.querySelectorAll('.clock');
 
-  // Populate datalist with time zones
-    const timeInputLabel = document.getElementById('timeInputLabel');
   const leftLabel = document.getElementById('leftLabel');
   const rightLabel = document.getElementById('rightLabel');
-const timeLabelText = document.getElementById('timeLabelText');
-  const timeZones = (Intl.supportedValuesOf && Intl.supportedValuesOf('timeZone')) || [
-   
+  const timeLabelText = document.getElementById('timeLabelText');
+  const locationLabelText = document.getElementById('locationLabelText');
 
+  const timeZones = (Intl.supportedValuesOf && Intl.supportedValuesOf('timeZone')) || [
     'America/New_York',
     'America/Chicago',
     'America/Denver',
@@ -49,25 +48,28 @@ const timeLabelText = document.getElementById('timeLabelText');
 
     let baseDT;
 
-      if (direction === 'yourToTheir'yourToTheir') {
-    // Update UI labels
-   timeLabelText.textContent = 'Your Time:';
-    leftLabel.textContent = 'Your Time:';
-    rightLabel.textContent = 'Their Time:';
+    if (direction === 'yourToTheir') {
+      // Update UI labels
+      timeLabelText.textContent = 'Your Time:';
+      leftLabel.textContent = 'Your Time:';
+      rightLabel.textContent = 'Their Time:';
+      locationLabelText.textContent = 'Their Location:';
 
-    baseDT = DateTime.fromISO(yourTimeInput.value, { zone: yourZone });
-    yourTimeDisplay.textContent = baseDT.setZone(yourZone).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
-    theirTimeDisplay.textContent = baseDT.setZone(theirZone).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
-  } else {
-    // Update UI labels
-timeLabelText.textContent = 'Their Time:';
-    leftLabel.textContent = 'Their Time:';
-    rightLabel.textContent = 'Your Time:';
+      baseDT = DateTime.fromISO(yourTimeInput.value, { zone: yourZone });
+      yourTimeDisplay.textContent = baseDT.setZone(yourZone).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+      theirTimeDisplay.textContent = baseDT.setZone(theirZone).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+    } else {
+      // Update UI labels
+      timeLabelText.textContent = 'Their Time:';
+      leftLabel.textContent = 'Their Time:';
+      rightLabel.textContent = 'Your Time:';
+      locationLabelText.textContent = 'Your Location:';
 
-    baseDT = DateTime.fromISO(yourTimeInput.value, { zone: theirZone });
-    theirTimeDisplay.textContent = baseDT.setZone(theirZone).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
-    yourTimeDisplay.textContent = baseDT.setZone(yourZone).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
-  }}
+      baseDT = DateTime.fromISO(yourTimeInput.value, { zone: theirZone });
+      theirTimeDisplay.textContent = baseDT.setZone(theirZone).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+      yourTimeDisplay.textContent = baseDT.setZone(yourZone).toLocaleString(DateTime.DATETIME_MED_WITH_SECONDS);
+    }
+  }
 
   // Update clocks
   function updateClocks() {
@@ -77,6 +79,17 @@ timeLabelText.textContent = 'Their Time:';
       el.querySelector('.time').textContent = now.setZone(tz).toLocaleString(DateTime.TIME_WITH_SECONDS);
     });
   }
+
+  // Toggle direction with button
+  toggleButton.addEventListener('click', () => {
+    const newDirection = directionSelect.value === 'yourToTheir' ? 'theirToYour' : 'yourToTheir';
+    directionSelect.value = newDirection;
+    if (newDirection === 'theirToYour') {
+      theirLocationInput.value = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    }
+    yourTimeInput.value = DateTime.local().startOf('minute').toISO({ suppressSeconds: true, includeOffset: false });
+    updateResult();
+  });
 
   // Event listeners
   yourTimeInput.addEventListener('input', updateResult);

--- a/style.css
+++ b/style.css
@@ -30,9 +30,9 @@ h1 {
 
 .clock h3 {
   margin: 0 0 10px;
-  
   font-size: 1rem;
-  
+}
+
 /* --- 2025 visual enhancements --- */
 
 /* Floating effect for clocks */
@@ -75,9 +75,8 @@ body {
   background: linear-gradient(135deg, #eef2f7 0%, #f9fbfc 100%);
 }
 
-}
-
 .clock .time {
+  font-family: monospace;
   font-size: 1.2rem;
   font-weight: bold;
   letter-spacing: 1px;
@@ -95,6 +94,16 @@ form#converter label {
   display: flex;
   flex-direction: column;
   font-weight: bold;
+}
+
+.toggle-btn {
+  align-self: center;
+  padding: 8px 12px;
+  font-size: 1.5rem;
+  cursor: pointer;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 form#converter input {
@@ -142,8 +151,13 @@ form#converter input {
 
 /* Patreon footer */
 .patreon {
+  max-width: 400px;
+  margin: 40px auto;
+  padding: 12px 20px;
   text-align: center;
-  margin-top: 30px;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   font-size: 0.95rem;
   color: #555;
 }


### PR DESCRIPTION
## Summary
- add label IDs and update text when toggling direction
- set default zone and time when the swap button is used
- style the Patreon advert as a centered card
- use a monospace font for digital clock readout

## Testing
- `npm test` *(fails: Could not read package.json)*